### PR TITLE
Tests for delimited local open with overriding

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1421,6 +1421,8 @@ simple_expr:
       { mkexp (Pexp_array []) }
   | mod_longident DOT LBRACKETBAR expr_semi_list opt_semi BARRBRACKET
       { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp(Pexp_array(List.rev $4)))) }
+  | mod_longident DOTBANG LBRACKETBAR expr_semi_list opt_semi BARRBRACKET
+      { mkexp(Pexp_open(Override, mkrhs $1 1, mkexp(Pexp_array(List.rev $4)))) }
   | mod_longident DOT LBRACKETBAR BARRBRACKET
       { mkexp(Pexp_open(Fresh, mkrhs $1 1, mkexp(Pexp_array []))) }
   | mod_longident DOTBANG LBRACKETBAR BARRBRACKET

--- a/testsuite/tests/warnings/w44_45.ml
+++ b/testsuite/tests/warnings/w44_45.ml
@@ -64,4 +64,15 @@ and array =
 and record =
   S.{ x =value }, S.{ x = { test_label = (); other_label_shadower = () } }, S.{ x = (Constructor: Shadower.t) }, S.{ x = new c }, S.{ x = ( module Module : module_type ) }
 and objects =
-  object val x = value method m = S.{< x = value >} end, object val x = S.r method m = S.{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.{< x = ( module Module : module_type ) >} end  
+  object val x = value method m = S.{< x = value >} end, object val x = S.r method m = S.{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.{< x = ( module Module : module_type ) >} end
+
+let local_delimited_parens_with_override =
+  S.!( value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type ) )
+and list_override =
+  S.![value], S.![{ test_label = (); other_label_shadower = () }], S.![(Constructor: Shadower.t)], S.![new c], S.![( module Module : module_type )]
+and array_override =
+  S.![|value|], S.![|{ test_label = (); other_label_shadower = () }|], S.![|(Constructor: Shadower.t)|], S.![|new c|],  S.![|( module Module : module_type )|]
+and record_override =
+  S.!{ x =value }, S.!{ x = { test_label = (); other_label_shadower = () } }, S.!{ x = (Constructor: Shadower.t) }, S.!{ x = new c }, S.!{ x = ( module Module : module_type ) }
+and objects_override =
+  object val x = value method m = S.!{< x = value >} end, object val x = S.r method m = S.!{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.!{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.!{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.!{< x = ( module Module : module_type ) >} end

--- a/testsuite/tests/warnings/w44_45.ml
+++ b/testsuite/tests/warnings/w44_45.ml
@@ -1,0 +1,67 @@
+
+  (* auxiliary type *)
+  type 'a box = { x : ' a}
+
+  (* Identifiers to be shadowed *)
+  let value = 1
+  type t = Constructor
+  class c = object end
+  module Module = struct end
+  type record = { test_label : unit; other_label : unit }
+  module type module_type = sig end
+
+(* Shadowing module *)
+module Shadower = struct
+  let value = 2
+  type t = Constructor
+  type record = { test_label : unit; other_label_shadower : unit }
+  let r = { test_label = (); other_label_shadower = () }
+  class c = object end
+  module Module = struct end
+  module type module_type = sig end
+end;;
+
+(* First, test shadowing with global open *)
+module Global = struct
+  open Shadower (* Trigger warnings 44 and 45 *)
+  let value = value
+  let record = { test_label = (); other_label_shadower = () }
+  let constructor: Shadower.t  = Constructor
+  let o = new c
+  module Module = Module
+  module type  module_type = module_type
+end;;
+
+module Global_with_override = struct
+  open! Shadower (* explicit override : do not trigger warnings 44 and 45 *)
+  let value = value
+  let record = { test_label = (); other_label_shadower = () }
+  let constructor: Shadower.t  = Constructor
+  let o = new c
+  module Module = Module
+  module type  module_type = module_type
+end;;
+
+(* Then, test shadowing with local open *)
+let local =
+  let open Shadower in
+  let module Module : module_type = Module in
+  value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c
+
+let local_with_override =
+  let open! Shadower in
+  value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type )
+
+
+module S = Shadower (* Shadower is too long to type here *)
+(* Last, test shadowing with delimited local open *)
+let local_delimited_parens =
+  S.( value, { test_label = (); other_label_shadower = () } , (Constructor: Shadower.t) , new c, ( module Module : module_type ) )
+and list =
+  S.[value], S.[{ test_label = (); other_label_shadower = () }], S.[(Constructor: Shadower.t)], S.[new c], S.[( module Module : module_type )]
+and array =
+  S.[|value|], S.[|{ test_label = (); other_label_shadower = () }|], S.[|(Constructor: Shadower.t)|], S.[|new c|],  S.[|( module Module : module_type )|]
+and record =
+  S.{ x =value }, S.{ x = { test_label = (); other_label_shadower = () } }, S.{ x = (Constructor: Shadower.t) }, S.{ x = new c }, S.{ x = ( module Module : module_type ) }
+and objects =
+  object val x = value method m = S.{< x = value >} end, object val x = S.r method m = S.{< x = { test_label = (); other_label_shadower = () } >} end, object val x = S.Constructor method m = S.{< x = (Constructor: Shadower.t) >} end, object val x = new S.c  method m = S.{< x = new c >} end, object val x = ( module S.Module : S.module_type ) method m = S.{< x = ( module Module : module_type ) >} end  

--- a/testsuite/tests/warnings/w44_45.reference
+++ b/testsuite/tests/warnings/w44_45.reference
@@ -1,0 +1,84 @@
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 26, characters 2-15:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 47, characters 2-193:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 59, characters 2-130:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 61, characters 4-13:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 61, characters 15-65:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 61, characters 67-96:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 61, characters 98-107:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 61, characters 109-144:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 61, characters 109-144:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 63, characters 4-15:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 63, characters 17-69:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 63, characters 71-102:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 63, characters 104-115:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 63, characters 118-155:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 63, characters 118-155:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 65, characters 4-18:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 65, characters 20-76:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 65, characters 78-113:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 65, characters 115-130:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 65, characters 132-173:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 65, characters 132-173:
+Warning 44: this open statement shadows the module identifier Module (which is later used)
+File "w44_45.ml", line 67, characters 34-51:
+Warning 44: this open statement shadows the value identifier value (which is later used)
+File "w44_45.ml", line 67, characters 87-145:
+Warning 45: this open statement shadows the label test_label (which is later used)
+File "w44_45.ml", line 67, characters 191-228:
+Warning 45: this open statement shadows the constructor Constructor (which is later used)
+File "w44_45.ml", line 67, characters 269-286:
+Warning 44: this open statement shadows the class identifier c (which is later used)
+File "w44_45.ml", line 67, characters 354-397:
+Warning 44: this open statement shadows the module type identifier module_type (which is later used)
+File "w44_45.ml", line 67, characters 354-397:
+Warning 44: this open statement shadows the module identifier Module (which is later used)


### PR DESCRIPTION
I have added the missing test(s) and the `M.[| expression |]` array case. 
Feel free to use the patch however you want.
